### PR TITLE
Add cyberpunk styling to homepage

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -610,6 +610,148 @@ pre {
 }
 
 /**
+ * Cyber homepage styles
+ */
+.cyber-home {
+  position: relative;
+  padding: 3rem 1.5rem 4rem;
+  color: #d6f6ff;
+  background: radial-gradient(circle at top, rgba(24, 42, 80, 0.9), rgba(6, 9, 18, 0.98));
+  border: 1px solid rgba(57, 255, 220, 0.25);
+  box-shadow: 0 0 24px rgba(57, 255, 220, 0.2);
+  overflow: hidden;
+}
+
+.cyber-home::before,
+.cyber-home::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.cyber-home::before {
+  background-image: linear-gradient(transparent 94%, rgba(57, 255, 220, 0.08)),
+    linear-gradient(90deg, transparent 94%, rgba(57, 255, 220, 0.08));
+  background-size: 28px 28px;
+  opacity: 0.6;
+}
+
+.cyber-home::after {
+  background: radial-gradient(circle at 20% 20%, rgba(111, 255, 234, 0.2), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(125, 121, 255, 0.2), transparent 55%);
+}
+
+.cyber-hero {
+  position: relative;
+  z-index: 1;
+  border: 1px solid rgba(125, 121, 255, 0.35);
+  border-radius: 16px;
+  padding: 2rem;
+  background: rgba(10, 12, 24, 0.75);
+  box-shadow: 0 0 18px rgba(125, 121, 255, 0.3);
+}
+
+.cyber-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.25rem;
+  text-transform: uppercase;
+  color: #59fbe1;
+  padding: 0.4rem 0.8rem;
+  border: 1px solid rgba(89, 251, 225, 0.6);
+  border-radius: 999px;
+  box-shadow: 0 0 10px rgba(89, 251, 225, 0.4);
+}
+
+.cyber-profile {
+  margin-top: 1.5rem;
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.cyber-profile img {
+  border-radius: 12px;
+  border: 1px solid rgba(89, 251, 225, 0.6);
+  box-shadow: 0 0 18px rgba(89, 251, 225, 0.35);
+}
+
+.cyber-intro h2 {
+  font-size: 1.8rem;
+  color: #ffffff;
+  text-transform: uppercase;
+  letter-spacing: 0.15rem;
+  margin-bottom: 1rem;
+}
+
+.cyber-intro p {
+  color: rgba(214, 246, 255, 0.85);
+}
+
+.cyber-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.cyber-tags span {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(125, 121, 255, 0.6);
+  color: #b7b5ff;
+  font-size: 0.75rem;
+  letter-spacing: 0.1rem;
+  text-transform: uppercase;
+  background: rgba(18, 20, 40, 0.6);
+}
+
+.cyber-contact {
+  position: relative;
+  z-index: 1;
+  margin-top: 2.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.cyber-contact-card {
+  padding: 1.5rem 2rem;
+  border-radius: 14px;
+  border: 1px solid rgba(89, 251, 225, 0.35);
+  background: rgba(8, 12, 22, 0.9);
+  box-shadow: 0 0 16px rgba(89, 251, 225, 0.25);
+  text-align: center;
+}
+
+.cyber-contact-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.3rem;
+  text-transform: uppercase;
+  color: #59fbe1;
+}
+
+.cyber-contact-value {
+  margin-top: 0.75rem;
+  font-size: 1rem;
+  color: #ffffff;
+}
+
+@include media-query($on-palm) {
+  .cyber-home {
+    padding: 2.5rem 1rem 3rem;
+  }
+
+  .cyber-profile {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+}
+
+/**
  * Syntax highlighting styles
  */
 .highlight {

--- a/index.md
+++ b/index.md
@@ -5,17 +5,41 @@ title : Shi Li's Personal Homepage
 # permalink: /home/
 ---
 
-<figure><center>
-  <img width="200" src="/pics/profile.jpg"/>
-  <figcaption>Me with Soprano Saxphone</figcaption>
-</center></figure>
+<div class="cyber-home">
+  <section class="cyber-hero">
+    <div class="cyber-badge">ONLINE • SIGNAL STABLE</div>
+    <div class="cyber-profile">
+      <figure>
+        <img width="200" src="/pics/profile.jpg" alt="Profile photo"/>
+        <figcaption>Me with Soprano Saxphone</figcaption>
+      </figure>
+      <div class="cyber-intro">
+        <h2>Shi Li / Cyber-Mechanical Engineer</h2>
+        <p>
+          I am Shi Li from University of Michigan, studying as a Mechanical Engineer with a MS degree.
+          I have been actively doing computer vision research at the UM &amp; Ford Center for Autonomous
+          Vehicles (FCAV). My research work includes: Velodyne Lidar scan pattern simulation, 3D image
+          segmentation and RGB-D image detection. I am targeting opportunities to work on Autonomous
+          Vehicle and Driver Assistance systems related technologies.
+        </p>
+        <p>
+          I believe I can not only apply the knowledge I learned from school to the industry world but
+          also come up with creative and novel solutions that will bring the customers even better experience.
+        </p>
+        <div class="cyber-tags">
+          <span>Computer Vision</span>
+          <span>Autonomous Systems</span>
+          <span>3D Perception</span>
+          <span>RGB-D Detection</span>
+        </div>
+      </div>
+    </div>
+  </section>
 
-
-I am Shi Li from University of Michigan, studying as a Mechanical Engineer  with a MS degree. I have been actively doing computer vision research at the UM & Ford Center for Autonomous Vehicles (FCAV). My research work includes: Velodyne Lidar scan pattern simulation, 3D image segmentation and  RGB-D image detection. I am targeting opportunities to work on Autonomous Vehicle and Driver Assistance systems related technologies.
-
-I believe I can not only apply the knowledge I learned from school to the industry world but also come up with creative and novel solutions that will bring the customers even better experience. 
-
-<center>
-<b>Contact</b> <br>
-shili at saicmotor.com <br>
-</center>
+  <section class="cyber-contact">
+    <div class="cyber-contact-card">
+      <div class="cyber-contact-label">CONTACT</div>
+      <div class="cyber-contact-value">shili at saicmotor.com</div>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
### Motivation
- Restyle the homepage to a cyber/neo-noir aesthetic and reorganize the markup to present the profile, skills, and contact information in a modern hero layout.

### Description
- Replaced the original centered figure and plain contact block in `index.md` with a structured `div.cyber-home` containing `section.cyber-hero`, `cyber-profile`, `cyber-intro`, `cyber-tags`, and `section.cyber-contact` to better separate content and presentation.
- Added scoped CSS rules to `css/style.scss` that implement radial gradients, neon borders and glows, a badge, tag chips, a responsive two-column grid for profile/intro, and a styled contact card with mobile adjustments via `@include media-query($on-palm)`.
- Added an `alt` attribute to the profile image for improved accessibility.
- All changes are localized to `index.md` and `css/style.scss`.

### Testing
- Attempted to run `jekyll serve --host 0.0.0.0 --port 4000` to preview the site, but the command failed with `command not found` so a local site build could not be verified.
- No automated CSS compilation or visual regression tests were run after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982f22b41e883318bdffdc1f7e1dff0)