### PR TITLE
Refresh cyber-styled bio, contact, and CV content

### DIFF
--- a/CV.md
+++ b/CV.md
@@ -5,7 +5,29 @@ layout: page
 weight : 6
 #tagline: last edit 11/15/2018
 ---
-### To be completed ...
+### Professional Summary
+
+Senior AI Scientist at Bosch specializing in GenAI solutions for SAP-era enterprise transformation. I design
+AI-driven automation and decision systems that unlock operational efficiency, business intelligence, and innovation
+at scale.
+
+### Experience
+
+**Senior AI Scientist** — Bosch (China) Investment Ltd.  
+*Mar 2025 – Present · Shanghai, China · On-site*  
+- Build GenAI workflows that modernize SAP business processes with intelligent automation and decision-grade insights.
+- Deliver production-ready AI systems that boost enterprise efficiency and innovation velocity.
+
+**Senior Computer Vision Engineer - CV** — 博世汽车部件（苏州）有限公司  
+*Sep 2020 – Feb 2025 · Pudong, Shanghai, China · On-site*  
+- Led agile development for computer vision systems used in production environments.
+- Built and deployed PyTorch-based models for real-world perception workloads.
+
+**Software Engineer** — SAIC Motor Technical Center  
+*Apr 2018 – Sep 2020 · Shanghai, China*  
+- Maintained FOTA software following ASPICE (ENG4–ENG8) for secure remote ECU reflashing.
+- Owned requirements analysis and detailed design for OTA signal changes and vehicle control unit updates.
+- Delivered virtual dashboard features, including IVDS data transfer and production bench testing.
 
 <!---
 MIT Kavli Institute, Massachusetts Institute of Technology\\

--- a/about.md
+++ b/about.md
@@ -4,5 +4,12 @@ title : Shi Li - About Me
 permalink: /about/
 weight : 6
 ---
-### To be completed ...
+### About Me
 
+I am a Senior AI Scientist at Bosch, operating at the intersection of GenAI and enterprise systems. My mission is to
+upgrade SAP-era workflows into intelligent, automated, and insight-driven pipelines that keep businesses ahead of the
+curve.
+
+I specialize in building production-ready AI systems that enhance efficiency, decision quality, and operational
+resilience. My interests include enterprise automation, scalable AI architectures, and cyber-styled innovation that
+turns data into strategic action.

--- a/index.md
+++ b/index.md
@@ -14,23 +14,22 @@ title : Shi Li's Personal Homepage
         <figcaption>Me with Soprano Saxphone</figcaption>
       </figure>
       <div class="cyber-intro">
-        <h2>Shi Li / Cyber-Mechanical Engineer</h2>
+        <h2>Shi Li / Senior AI Scientist</h2>
         <p>
-          I am Shi Li from University of Michigan, studying as a Mechanical Engineer with a MS degree.
-          I have been actively doing computer vision research at the UM &amp; Ford Center for Autonomous
-          Vehicles (FCAV). My research work includes: Velodyne Lidar scan pattern simulation, 3D image
-          segmentation and RGB-D image detection. I am targeting opportunities to work on Autonomous
-          Vehicle and Driver Assistance systems related technologies.
+          Signal update: I am a Senior AI Scientist at Bosch, engineering GenAI systems that rewire SAP-era business
+          processes for intelligent automation and decision-grade insights. I build next-gen AI pipelines that turn
+          enterprise data into faster decisions and smarter operations.
         </p>
         <p>
-          I believe I can not only apply the knowledge I learned from school to the industry world but
-          also come up with creative and novel solutions that will bring the customers even better experience.
+          My focus: AI-driven efficiency, enterprise intelligence, and pragmatic innovation. I design solutions that
+          are scalable, secure, and ready for production—so businesses can move faster in a digital-first world.
         </p>
         <div class="cyber-tags">
-          <span>Computer Vision</span>
-          <span>Autonomous Systems</span>
-          <span>3D Perception</span>
-          <span>RGB-D Detection</span>
+          <span>GenAI</span>
+          <span>SAP Automation</span>
+          <span>Enterprise Intelligence</span>
+          <span>Decision Systems</span>
+          <span>AI Ops</span>
         </div>
       </div>
     </div>
@@ -39,7 +38,7 @@ title : Shi Li's Personal Homepage
   <section class="cyber-contact">
     <div class="cyber-contact-card">
       <div class="cyber-contact-label">CONTACT</div>
-      <div class="cyber-contact-value">shili at saicmotor.com</div>
+      <div class="cyber-contact-value">shili at bosch.com</div>
     </div>
   </section>
 </div>


### PR DESCRIPTION
### Motivation

- Update the personal site content to reflect the current role and latest experience with a cyber-styled / ‘cyber’ tone. 
- Replace outdated placeholders and CV fragments with a concise production-oriented GenAI summary that targets enterprise/SAP use cases. 
- Adjust contact details and tag vocabulary to match the updated role and branding.

### Description

- Updated `index.md` hero section to a cyber-styled Senior AI Scientist summary, replaced skill tags with `GenAI`, `SAP Automation`, `Enterprise Intelligence`, `Decision Systems`, and `AI Ops`, and changed the contact email to `shili at bosch.com`.
- Rewrote `about.md` to a short, cyber-toned About Me that emphasizes GenAI-driven enterprise transformation and production-ready systems.
- Replaced the placeholder CV content in `CV.md` with an updated `Professional Summary` and refined `Experience` bullets for the Bosch, 博世 (Suzhou), and SAIC Motor roles.
- Staged and committed the changes with the message `Refresh cyber-styled bio and contact`.

### Testing

- Launched a local static server using `python -m http.server 8000` to serve the updated HTML and verify file rendering, which started successfully.
- Ran a Playwright-based visual smoke test script to capture `http://127.0.0.1:8000/index.html`, but the browser failed to launch due to a Chromium crash in this environment and the screenshot was not captured.
- No unit tests were required for these static content updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982fdd7cbf48331b487fe743e773193)